### PR TITLE
Add support for scheduled feature flags with `activeFrom` and `activeUntil`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,38 +2,28 @@ import {
   defineNuxtModule,
   createResolver,
   addPlugin,
-  addImportsDir, type Resolver,
+  addImportsDir,
 } from '@nuxt/kit'
-import type { Nuxt } from '@nuxt/schema'
 
-export interface FeatureFlagsOptions {
-  environment: string
-  environments: Record<string, string[]>
-}
+import type { FeatureFlagsConfig } from '../types/feature-flags'
 
-export default defineNuxtModule<FeatureFlagsOptions>({
+export default defineNuxtModule<FeatureFlagsConfig>({
   meta: {
     name: 'nuxt-feature-flags-module',
     configKey: 'featureFlags',
   },
-
   defaults: {
     environment: 'production',
     environments: {},
   },
+  setup(options, nuxt) {
+    const resolver = createResolver(import.meta.url)
 
-  setup(options: FeatureFlagsOptions, nuxt: Nuxt): void {
-    const resolver: Resolver = createResolver(import.meta.url)
+    nuxt.options.runtimeConfig.public.featureFlags = options
+    nuxt.options.runtimeConfig.featureFlags = options
 
-    // Inject into runtime config for both client + server
-    nuxt.options.runtimeConfig.public.featureFlags = options as FeatureFlagsOptions
-    nuxt.options.runtimeConfig.featureFlags = options as FeatureFlagsOptions
-
-    // Register composables (useFeatureFlag)
     addImportsDir(resolver.resolve('runtime/composables'))
-
     addPlugin(resolver.resolve('runtime/plugin'))
-
     addImportsDir(resolver.resolve('runtime/middleware'))
   },
 })

--- a/src/runtime/directives/v-feature.ts
+++ b/src/runtime/directives/v-feature.ts
@@ -1,17 +1,28 @@
 import type { Directive } from 'vue'
-import type { FeatureFlagsConfig } from '../../../types/feature-flags'
+import type { FeatureFlagsConfig, FeatureFlag, FeatureFlagInput } from '../../../types/feature-flags'
+import { useRuntimeConfig } from '#imports'
+
+const isFlagActiveNow = (flag: FeatureFlag): boolean => {
+  const now = Date.now()
+  const from = flag.activeFrom ? Date.parse(flag.activeFrom) : -Infinity
+  const until = flag.activeUntil ? Date.parse(flag.activeUntil) : Infinity
+  return now >= from && now <= until
+}
 
 export const vFeature: Directive = {
-  mounted(el, binding): void {
+  mounted(el: HTMLElement, binding: { value: string }) {
     const config: FeatureFlagsConfig = useRuntimeConfig().public.featureFlags
     const env: string = config.environment
-    const flags: string[] = config.environments?.[env] || []
+    const flags: FeatureFlagInput[] = config.environments?.[env] || []
 
-    const feature = binding.value
-    const enabled: boolean = flags.includes(feature)
+    const featureName = binding.value
+    let enabled = false
 
-    if (!enabled) {
-      el.style.display = 'none'
+    for (const flag of flags) {
+      if (typeof flag === 'string' && flag === featureName) enabled = true
+      if (typeof flag === 'object' && flag.name === featureName && isFlagActiveNow(flag)) enabled = true
     }
+
+    if (!enabled) el.style.display = 'none'
   },
 }

--- a/src/runtime/server/isFeatureEnabled.ts
+++ b/src/runtime/server/isFeatureEnabled.ts
@@ -1,8 +1,22 @@
 import type { H3Event } from 'h3'
+import type { FeatureFlag } from '../../../types/feature-flags'
+
+const isFlagActiveNow = (flag: FeatureFlag): boolean => {
+  const now = Date.now()
+  const from = flag.activeFrom ? Date.parse(flag.activeFrom) : -Infinity
+  const until = flag.activeUntil ? Date.parse(flag.activeUntil) : Infinity
+  return now >= from && now <= until
+}
 
 export const isFeatureEnabled = (feature: string, event?: H3Event): boolean => {
   const config = useRuntimeConfig(event).featureFlags
   const env = config.environment
   const flags = config.environments?.[env] || []
-  return flags.includes(feature)
+
+  for (const flag of flags) {
+    if (typeof flag === 'string' && flag === feature) return true
+    if (typeof flag === 'object' && flag.name === feature && isFlagActiveNow(flag)) return true
+  }
+
+  return false
 }

--- a/types/feature-flags.d.ts
+++ b/types/feature-flags.d.ts
@@ -1,6 +1,14 @@
+export type FeatureFlagInput = string | FeatureFlag
+
+export interface FeatureFlag {
+  name: string
+  activeFrom?: string
+  activeUntil?: string
+}
+
 export interface FeatureFlagsConfig {
   environment: string
-  environments: Record<string, string[]>
+  environments: Record<string, FeatureFlagInput[]>
 }
 
 declare module 'nuxt/schema' {


### PR DESCRIPTION
## ✅ PR Checklist

Please ensure the following before submitting your PR:

- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I’ve tested the changes and confirmed they work as expected
- [x] I’ve updated any relevant documentation
- [ ] I’ve added tests (if applicable)

## 🔗 Linked Issue

No issue created

## 📖 Description

This PR introduces support for **time-based scheduled feature flags** using `activeFrom` and `activeUntil`:

- Feature flags can now be objects, not just strings
- Flags are only active if the current date is within the specified timeframe
- This works across:
  - the `useFeatureFlag()` composable
  - the `v-feature` directive
  - the `isFeatureEnabled()` server utility
- Updated types to support `FeatureFlagInput` (string | { name, activeFrom, activeUntil })
- Improved logic in directive and composable to handle mixed flag inputs
- Added full example support in the Playground

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how users should migrate -->

## 🧪 Type of Change

<!-- Mark the appropriate option(s) with an "x" -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code style / formatting
- [ ] 🔨 Refactoring (no functional changes)
- [ ] 🧰 Tooling / CI
- [x] 📝 Docs update
- [ ] 🧪 Tests
- [ ] 💡 Other (please describe):

## 🧩 Additional Context

Nothing
