### PR TITLE
refactor(v-feature): simplify feature flag directive using composable

### DIFF
--- a/src/runtime/directives/v-feature.ts
+++ b/src/runtime/directives/v-feature.ts
@@ -1,22 +1,9 @@
 import type { Directive } from 'vue'
-import type { FeatureFlagsConfig, FeatureFlagInput } from '../../../types/feature-flags'
-import { isFlagActiveNow } from '../utils/isFlagActiveNow'
-import { useRuntimeConfig } from '#imports'
+import { useFeatureFlag } from '../composables/useFeatureFlag'
 
 export const vFeature: Directive = {
   mounted(el: HTMLElement, binding: { value: string }) {
-    const config: FeatureFlagsConfig = useRuntimeConfig().public.featureFlags
-    const env: string = config.environment
-    const flags: FeatureFlagInput[] = config.environments?.[env] || []
-
-    const featureName = binding.value
-    let enabled = false
-
-    for (const flag of flags) {
-      if (typeof flag === 'string' && flag === featureName) enabled = true
-      if (typeof flag === 'object' && flag.name === featureName && isFlagActiveNow(flag)) enabled = true
-    }
-
-    if (!enabled) el.style.display = 'none'
+    const { isEnabled } = useFeatureFlag()
+    if (!isEnabled(binding.value)) el.style.display = 'none'
   },
 }


### PR DESCRIPTION
## ✅ PR Checklist

Please ensure the following before submitting your PR:

- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I’ve tested the changes and confirmed they work as expected
- [ ] I’ve updated any relevant documentation
- [ ] I’ve added tests (if applicable)

## 🔗 Linked Issue

No issue created

## 📖 Description

This PR refactors the `v-feature` directive to reuse the shared `isEnabled()` logic from the `useFeatureFlag` composable.
This reduces duplicated logic and ensures consistent behavior across composable and directive usage.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how users should migrate -->

## 🧪 Type of Change

<!-- Mark the appropriate option(s) with an "x" -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code style / formatting
- [x] 🔨 Refactoring (no functional changes)
- [ ] 🧰 Tooling / CI
- [ ] 📝 Docs update
- [ ] 🧪 Tests
- [ ] 💡 Other (please describe):

## 🧩 Additional Context

<!-- Add screenshots, notes, or any other context relevant to this change -->

Thank you for contributing! 💚
