### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/test/unit/defineFeatureFlagMiddleware.test.ts
+++ b/test/unit/defineFeatureFlagMiddleware.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockIsEnabled = vi.fn()
+const mockShowError = vi.fn()
+const mockDefineNuxtRouteMiddleware = vi.fn((fn: any) => fn)
+
+vi.mock('#app', () => ({
+  defineNuxtRouteMiddleware: (...args: any[]) => mockDefineNuxtRouteMiddleware(...args),
+  showError: (...args: any[]) => mockShowError(...args),
+}))
+vi.mock('../../src/runtime/composables/useFeatureFlag', () => ({
+  useFeatureFlag: () => ({ isEnabled: mockIsEnabled }),
+}))
+
+// Import dynamically after mocks are registered
+const importMiddleware = () => import('../../src/runtime/middleware/defineFeatureFlagMiddleware')
+
+beforeEach(() => {
+  mockIsEnabled.mockReset()
+  mockShowError.mockReset()
+  mockDefineNuxtRouteMiddleware.mockReset()
+})
+
+describe('defineFeatureFlagMiddleware', () => {
+  it('calls showError when feature is disabled', async () => {
+    mockIsEnabled.mockReturnValue(false)
+    const { defineFeatureFlagMiddleware } = await importMiddleware()
+    const middleware = defineFeatureFlagMiddleware('flagA')
+    middleware()
+    expect(mockShowError).toHaveBeenCalled()
+  })
+
+  it('allows navigation when feature is enabled', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    const { defineFeatureFlagMiddleware } = await importMiddleware()
+    const middleware = defineFeatureFlagMiddleware('flagA')
+    const result = middleware()
+    expect(result).toBeUndefined()
+    expect(mockShowError).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/flagValidator.test.ts
+++ b/test/unit/flagValidator.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { validateFeatureFlags } from '../../src/runtime/utils/flagValidator'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'ff-'))
+})
+
+afterEach(async () => {
+  // cleanup automatically by tmpdir removal on container end
+})
+
+describe('flagValidator', () => {
+  it('warns on missing flags in warn mode', async () => {
+    const file = join(dir, 'test.ts')
+    await writeFile(file, "isEnabled('missing')")
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await validateFeatureFlags({
+      environment: 'prod',
+      environments: { prod: [] },
+      validation: { mode: 'warn', includeGlobs: ['**/*.ts'], excludeGlobs: [] },
+    }, dir)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('throws on missing flags in error mode', async () => {
+    const file = join(dir, 'test2.ts')
+    await writeFile(file, "isEnabled('missing')")
+    await expect(validateFeatureFlags({
+      environment: 'prod',
+      environments: { prod: [] },
+      validation: { mode: 'error', includeGlobs: ['**/*.ts'], excludeGlobs: [] },
+    }, dir)).rejects.toThrow()
+  })
+})

--- a/test/unit/isFeatureEnabled.test.ts
+++ b/test/unit/isFeatureEnabled.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { isFeatureEnabled } from '../../src/runtime/server/isFeatureEnabled'
+
+let runtimeConfig: any
+
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+beforeEach(() => {
+  runtimeConfig = {
+    featureFlags: {
+      environment: 'prod',
+      environments: {
+        prod: [],
+      },
+    },
+  }
+})
+
+describe('isFeatureEnabled', () => {
+  it('checks simple string flags', () => {
+    runtimeConfig.featureFlags.environments.prod = ['flagA']
+    expect(isFeatureEnabled('flagA')).toBe(true)
+    expect(isFeatureEnabled('unknown')).toBe(false)
+  })
+
+  it('evaluates scheduled flags', () => {
+    const now = new Date('2024-06-01T12:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    runtimeConfig.featureFlags.environments.prod = [
+      { name: 'scheduled', activeUntil: '2024-07-01T00:00:00Z' },
+    ]
+
+    expect(isFeatureEnabled('scheduled')).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('returns false when flag is inactive', () => {
+    const now = new Date('2024-08-01T12:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    runtimeConfig.featureFlags.environments.prod = [
+      { name: 'scheduled', activeUntil: '2024-07-01T00:00:00Z' },
+    ]
+
+    expect(isFeatureEnabled('scheduled')).toBe(false)
+    vi.useRealTimers()
+  })
+})

--- a/test/unit/isFlagActiveNow.test.ts
+++ b/test/unit/isFlagActiveNow.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { isFlagActiveNow } from '../../src/runtime/utils/isFlagActiveNow'
+
+// Use a fixed system time for deterministic results
+const now = new Date('2024-06-01T12:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(now)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('isFlagActiveNow', () => {
+  it('returns true when no dates are provided', () => {
+    expect(isFlagActiveNow({ name: 'test' })).toBe(true)
+  })
+
+  it('respects activeFrom and activeUntil window', () => {
+    const flag = { name: 'test', activeFrom: '2024-05-01T00:00:00Z', activeUntil: '2024-07-01T00:00:00Z' }
+    expect(isFlagActiveNow(flag)).toBe(true)
+  })
+
+  it('returns false when before activeFrom', () => {
+    const flag = { name: 'test', activeFrom: '2024-06-02T00:00:00Z' }
+    expect(isFlagActiveNow(flag)).toBe(false)
+  })
+
+  it('returns false when after activeUntil', () => {
+    const flag = { name: 'test', activeUntil: '2024-05-01T00:00:00Z' }
+    expect(isFlagActiveNow(flag)).toBe(false)
+  })
+
+  it('returns false for invalid date strings', () => {
+    const flag = { name: 'test', activeFrom: 'not-a-date' }
+    expect(isFlagActiveNow(flag)).toBe(false)
+  })
+})

--- a/test/unit/useFeatureFlag.test.ts
+++ b/test/unit/useFeatureFlag.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useFeatureFlag } from '../../src/runtime/composables/useFeatureFlag'
+
+let runtimeConfig: any
+
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+beforeEach(() => {
+  runtimeConfig = {
+    public: {
+      featureFlags: {
+        environment: 'prod',
+        environments: {
+          prod: [],
+        },
+      },
+    },
+  }
+})
+
+describe('useFeatureFlag', () => {
+  it('detects static flags', () => {
+    runtimeConfig.public.featureFlags.environments.prod = ['flagA']
+    const { isEnabled } = useFeatureFlag()
+    expect(isEnabled('flagA')).toBe(true)
+    expect(isEnabled('unknown')).toBe(false)
+  })
+
+  it('handles scheduled flags', () => {
+    const now = new Date('2024-06-01T12:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    runtimeConfig.public.featureFlags.environments.prod = [
+      { name: 'scheduled', activeFrom: '2024-05-01T00:00:00Z', activeUntil: '2024-07-01T00:00:00Z' },
+    ]
+
+    const { isEnabled, listFlags } = useFeatureFlag()
+    expect(isEnabled('scheduled')).toBe(true)
+    expect(listFlags()).toEqual(['scheduled'])
+
+    vi.useRealTimers()
+  })
+
+  it('filters out inactive scheduled flags', () => {
+    const now = new Date('2024-04-01T12:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    runtimeConfig.public.featureFlags.environments.prod = [
+      { name: 'scheduled', activeFrom: '2024-05-01T00:00:00Z' },
+    ]
+
+    const { isEnabled, listFlags } = useFeatureFlag()
+    expect(isEnabled('scheduled')).toBe(false)
+    expect(listFlags()).toEqual([])
+
+    vi.useRealTimers()
+  })
+})

--- a/test/unit/vFeature.test.ts
+++ b/test/unit/vFeature.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const mockIsEnabled = vi.fn()
+
+vi.mock('../../src/runtime/composables/useFeatureFlag', () => ({
+  useFeatureFlag: () => ({ isEnabled: mockIsEnabled })
+}))
+
+import { vFeature } from '../../src/runtime/directives/v-feature'
+
+describe('vFeature directive', () => {
+  it('hides element when feature is disabled', () => {
+    mockIsEnabled.mockReturnValue(false)
+    const el = { style: {} } as HTMLElement
+    vFeature.mounted!(el, { value: 'myFlag' } as any)
+    expect((el as any).style.display).toBe('none')
+  })
+
+  it('does nothing when feature is enabled', () => {
+    mockIsEnabled.mockReturnValue(true)
+    const el = { style: {} } as HTMLElement
+    vFeature.mounted!(el, { value: 'myFlag' } as any)
+    expect((el as any).style.display).not.toBe('none')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for isFlagActiveNow helper
- add unit tests for useFeatureFlag composable
- add unit tests for server isFeatureEnabled util
- add unit tests for v-feature directive
- add unit tests for feature flag middleware
- add unit tests for flag validator

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68400273ab448333abf0342f650b3540