### PR TITLE
refactor(config): rename `flags` to `flagSets` in feature flag configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
   modules: ['nuxt-feature-flags-module'],
   featureFlags: {
     environment: process.env.FEATURE_ENV || 'development',
-    flags: {
+    flagSets: {
       development: ['yourFeature1', 'yourFeature2'],
       staging: ['yourFeature1'],
       production: []

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
 
   featureFlags: {
     environment: process.env.FEATURE_ENV || 'development',
-    flags: {
+    flagSets: {
       development: [
         'newSystem',
         'betaButton',

--- a/playground/pages/scheduled.vue
+++ b/playground/pages/scheduled.vue
@@ -79,7 +79,7 @@ const config = useRuntimeConfig().public.featureFlags
 
 const scheduledFlags = computed(() => {
   const env = config.environment
-  const flags = config.flags?.[env] || []
+  const flags = config.flagSets?.[env] || []
 
   return flags.filter((flag): flag is { name: string, activeFrom?: string, activeUntil?: string } => {
     return typeof flag === 'object' && typeof flag.name === 'string'

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,7 +19,7 @@ export default defineNuxtModule<FeatureFlagsConfig>({
     environment: 'production',
 
     // No flags declared by default
-    flags: {},
+    flagSets: {},
 
     validation: {
       mode: 'warn', // can be 'disabled' | 'warn' | 'error'
@@ -41,7 +41,7 @@ export default defineNuxtModule<FeatureFlagsConfig>({
     nuxt.hook('ready', async (): Promise<void> => {
       if ('environments' in (options as FeatureFlagsConfig)) {
         throw new Error(
-          '`featureFlags.environments` has been renamed to `featureFlags.flags`. '
+          '`featureFlags.environments` has been renamed to `featureFlags.flagSets`. '
           + 'See release notes for v2025.6.2 for migration details.',
         )
       }

--- a/src/runtime/composables/useFeatureFlag.ts
+++ b/src/runtime/composables/useFeatureFlag.ts
@@ -13,7 +13,7 @@ import { useRuntimeConfig } from '#imports'
 export const useFeatureFlag = () => {
   const config: FeatureFlagsConfig = useRuntimeConfig().public.featureFlags
   const env = config.environment
-  const flags: FeatureFlagInput[] = config.flags?.[env] || []
+  const flags: FeatureFlagInput[] = config.flagSets?.[env] || []
 
   /**
    * Checks whether a feature flag is currently enabled.

--- a/src/runtime/server/isFeatureEnabled.ts
+++ b/src/runtime/server/isFeatureEnabled.ts
@@ -23,7 +23,7 @@ import type { FeatureFlagInput, FeatureFlagsConfig } from '~/types/feature-flags
 export const isFeatureEnabled = (feature: string, event?: H3Event): boolean => {
   const config: FeatureFlagsConfig = useRuntimeConfig(event).featureFlags
   const env: string = config.environment
-  const flags: FeatureFlagInput[] = config.flags?.[env] || []
+  const flags: FeatureFlagInput[] = config.flagSets?.[env] || []
 
   for (const flag of flags) {
     if (typeof flag === 'string' && flag === feature) return true

--- a/src/runtime/utils/flagValidator.ts
+++ b/src/runtime/utils/flagValidator.ts
@@ -19,7 +19,7 @@ import type { FeatureFlagsConfig } from '../../../types/feature-flags'
  *
  * For each missing flag, it includes file path, line, and column in the warning/error.
  *
- * @param options - Feature flag configuration (including `flags` and `validation`).
+ * @param options - Feature flag configuration (including `flagSets` and `validation`).
  * @param rootDir  - Absolute path to the Nuxt project root directory.
  */
 export async function validateFeatureFlags(
@@ -33,8 +33,8 @@ export async function validateFeatureFlags(
     return // Skip validation entirely
   }
 
-  // 1. If no flags defined → skip
-  if (!options.flags || Object.keys(options.flags).length === 0) {
+  // 1. If no flagSets defined → skip
+  if (!options.flagSets || Object.keys(options.flagSets).length === 0) {
     return
   }
 
@@ -110,9 +110,9 @@ export async function validateFeatureFlags(
     }
   }
 
-  // 7. Build Set of all declared flags (across all flags in all environments)
+  // 7. Build Set of all declared flags (across all flags in all flagSets)
   const declaredFlags: Set<string> = new Set<string>()
-  for (const envFlags of Object.values(options.flags)) {
+  for (const envFlags of Object.values(options.flagSets)) {
     for (const item of envFlags || []) {
       const name: string = typeof item === 'string' ? item : item.name
       declaredFlags.add(name)

--- a/test/unit/flagValidator.test.ts
+++ b/test/unit/flagValidator.test.ts
@@ -21,7 +21,7 @@ describe('flagValidator', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await validateFeatureFlags({
       environment: 'prod',
-      flags: { prod: [] },
+      flagSets: { prod: [] },
       validation: { mode: 'warn', includeGlobs: ['**/*.ts'], excludeGlobs: [] },
     }, dir)
     expect(warnSpy).toHaveBeenCalled()
@@ -33,7 +33,7 @@ describe('flagValidator', () => {
     await writeFile(file, 'isEnabled(\'missing\')')
     await expect(validateFeatureFlags({
       environment: 'prod',
-      flags: { prod: [] },
+      flagSets: { prod: [] },
       validation: { mode: 'error', includeGlobs: ['**/*.ts'], excludeGlobs: [] },
     }, dir)).rejects.toThrow()
   })

--- a/test/unit/isFeatureEnabled.test.ts
+++ b/test/unit/isFeatureEnabled.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
   runtimeConfig = {
     featureFlags: {
       environment: 'prod',
-      flags: {
+      flagSets: {
         prod: [],
       },
     },
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('isFeatureEnabled', () => {
   it('checks simple string flags', () => {
-    runtimeConfig.featureFlags.flags.prod = ['flagA']
+    runtimeConfig.featureFlags.flagSets.prod = ['flagA']
     expect(isFeatureEnabled('flagA')).toBe(true)
     expect(isFeatureEnabled('unknown')).toBe(false)
   })
@@ -35,7 +35,7 @@ describe('isFeatureEnabled', () => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
 
-    runtimeConfig.featureFlags.flags.prod = [
+    runtimeConfig.featureFlags.flagSets.prod = [
       { name: 'scheduled', activeUntil: '2024-07-01T00:00:00Z' },
     ]
 
@@ -48,7 +48,7 @@ describe('isFeatureEnabled', () => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
 
-    runtimeConfig.featureFlags.flags.prod = [
+    runtimeConfig.featureFlags.flagSets.prod = [
       { name: 'scheduled', activeUntil: '2024-07-01T00:00:00Z' },
     ]
 

--- a/test/unit/useFeatureFlag.test.ts
+++ b/test/unit/useFeatureFlag.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
     public: {
       featureFlags: {
         environment: 'prod',
-        flags: {
+        flagSets: {
           prod: [],
         },
       },
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe('useFeatureFlag', () => {
   it('detects static flags', () => {
-    runtimeConfig.public.featureFlags.flags.prod = ['flagA']
+    runtimeConfig.public.featureFlags.flagSets.prod = ['flagA']
     const { isEnabled } = useFeatureFlag()
     expect(isEnabled('flagA')).toBe(true)
     expect(isEnabled('unknown')).toBe(false)
@@ -40,7 +40,7 @@ describe('useFeatureFlag', () => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
 
-    runtimeConfig.public.featureFlags.flags.prod = [
+    runtimeConfig.public.featureFlags.flagSets.prod = [
       { name: 'scheduled', activeFrom: '2024-05-01T00:00:00Z', activeUntil: '2024-07-01T00:00:00Z' },
     ]
 
@@ -56,7 +56,7 @@ describe('useFeatureFlag', () => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
 
-    runtimeConfig.public.featureFlags.flags.prod = [
+    runtimeConfig.public.featureFlags.flagSets.prod = [
       { name: 'scheduled', activeFrom: '2024-05-01T00:00:00Z' },
     ]
 

--- a/types/feature-flags.d.ts
+++ b/types/feature-flags.d.ts
@@ -30,7 +30,7 @@ export interface FeatureFlagsConfig {
   /**
    * A record mapping each environment to an array of flags (string or { name, activeFrom, activeUntil }).
    */
-  flags: Record<string, FeatureFlagInput[]>
+  flagSets: Record<string, FeatureFlagInput[]>
 
   /**
    * Advanced validation options:


### PR DESCRIPTION
## ✅ PR Checklist

Please ensure the following before submitting your PR:

- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I’ve tested the changes and confirmed they work as expected
- [x] I’ve updated any relevant documentation
- [ ] I’ve added tests (if applicable)

## 🔗 Linked Issue

No issue created.

## 📖 Description

<!-- Clearly explain what this PR changes, why it’s needed, and what problem it solves -->

This PR renames the top-level `featureFlags.environments` configuration option to `featureFlags.flagSets`.

This change improves clarity and avoids confusion with the separate `featureFlags.environment` key, which defines the *current environment*. The new name `flagSets` better represents its purpose: a set of feature flags assigned per environment (or scope).

Previously, this option was temporarily renamed to `flags`, but that naming caused structural ambiguity and semantic mismatch — `flags` described both the top-level object and the individual flag arrays inside. Renaming it to `flagSets` brings more structure and makes the configuration easier to reason about.

## 🚨 Breaking Changes

- [x] Yes
- [ ] No

<!-- If yes, describe what breaks and how users should migrate -->

* `featureFlags.environments` has been renamed to `featureFlags.flagSets`.
* Users must migrate their config like this:

**Before:**

```ts
featureFlags: {
  environment: 'development',
  environments: {
    development: ['featureA'],
    production: ['featureB']
  }
}
```

**After:**

```ts
featureFlags: {
  environment: 'development',
  flagSets: {
    development: ['featureA'],
    production: ['featureB']
  }
}
```

## 🧪 Type of Change

<!-- Mark the appropriate option(s) with an "x" -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code style / formatting
- [x] 🔨 Refactoring (no functional changes)
- [ ] 🧰 Tooling / CI
- [ ] 📝 Docs update
- [ ] 🧪 Tests
- [ ] 💡 Other (please describe):

## 🧩 Additional Context

<!-- Add screenshots, notes, or any other context relevant to this change -->

In a previous commit, `featureFlags.environments` was renamed to `featureFlags.flags` in an attempt to simplify the config shape. However, this introduced a confusing dual use of the term `flags`, making it unclear whether `flags` referred to the environment mapping or the individual flag arrays.

Additionally, while `environments` was technically correct, it looked awkward and clashed visually with the separate `environment: '...'` key.

This refactor to `flagSets` solves both problems:

* It eliminates structural ambiguity.
* It improves naming clarity without the awkwardness of `environments`.

This change will be reflected in the documentation and will be part of the v2025.6.2 release.